### PR TITLE
Fix an bug for wrong cursorposition

### DIFF
--- a/src/main/java/com/simsilica/lemur/component/TextEntryComponent.java
+++ b/src/main/java/com/simsilica/lemur/component/TextEntryComponent.java
@@ -297,6 +297,9 @@ public class TextEntryComponent extends AbstractGuiComponent
         // The cursor is attached to the bitmap text directly
         // so we need to move it.       
         bitmapText.attachChild(cursor);
+        
+         // we also need to change the font! as the font parameter is used in getVisibleWidth()
+        this.font = font;
                 
         resizeCursor();
         resetCursorPosition();


### PR DESCRIPTION
The font parameter is used to calculate the visible width of texts. After creation of a textfield it is never changed. If the font is changed this may lead to wrong calculations of text width and things that are based on this calculation (e.g. cursor position, selected areas etc.)