### PR TITLE
Whole Listbox cells clickable

### DIFF
--- a/extensions/LemurProto/src/main/java/com/simsilica/lemur/ListBox.java
+++ b/extensions/LemurProto/src/main/java/com/simsilica/lemur/ListBox.java
@@ -417,7 +417,9 @@ public class ListBox<T> extends Panel {
     protected Panel getListCell( int row, int col, Panel existing ) {
         T value = model.get(row);
         Panel cell = cellRenderer.getView(value, false, existing);
- 
+     
+        if (cell.getBackground() == null) cell.setBackground(new QuadBackgroundComponent(new ColorRGBA(ColorRGBA.BlackNoAlpha)));
+                
         if( cell != existing ) {
             // Transfer the click listener                  
             CursorEventControl.addListenersToSpatial(cell, clickListener);


### PR DESCRIPTION
As discussed in 
https://hub.jmonkeyengine.org/t/lemur-listbox-area-of-clickbehaviour-and-layout-question/40916/6
this bug fix will add an invisible background to the Button in listboxes. That will allow the user to click the whole line in a listbox to achieve a selection. Otherwise he will be only able to select a line if he clicks the text area in listboxes.