### PR TITLE
Upgrade gradle and add constructor to IconComponent

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/src/main/java/com/simsilica/lemur/component/IconComponent.java
+++ b/src/main/java/com/simsilica/lemur/component/IconComponent.java
@@ -87,7 +87,20 @@ public class IconComponent extends AbstractGuiComponent
         this(imagePath, new Vector2f(iconScale, iconScale), xMargin, yMargin,
              zOffset, lit);                          
     }
-                              
+
+    public IconComponent( Texture texture, Vector2f iconScale,
+                          float xMargin, float yMargin, float zOffset,
+                          boolean lit ) {
+        this.imagePath = texture.getName();
+        this.image = texture;
+        this.iconScale = iconScale;
+        this.xMargin = xMargin;
+        this.yMargin = yMargin;
+        this.zOffset = zOffset;
+        this.lit = lit;
+        createIcon();
+    }
+
     public IconComponent( String imagePath, Vector2f iconScale,
                           float xMargin, float yMargin, float zOffset,
                           boolean lit ) {

--- a/src/main/java/com/simsilica/lemur/component/IconComponent.java
+++ b/src/main/java/com/simsilica/lemur/component/IconComponent.java
@@ -264,6 +264,13 @@ public class IconComponent extends AbstractGuiComponent
         invalidate();
     }
 
+    public void setMargin(Vector2f margin) {
+        this.xMargin = margin.x;
+        this.yMargin = margin.y;
+
+        invalidate();
+    }
+
     public Vector2f getMargin() {
         return new Vector2f(xMargin, yMargin);
     }

--- a/src/main/java/com/simsilica/lemur/component/QuadBackgroundComponent.java
+++ b/src/main/java/com/simsilica/lemur/component/QuadBackgroundComponent.java
@@ -199,6 +199,11 @@ public class QuadBackgroundComponent extends AbstractGuiComponent
         invalidate();
     }
 
+    public void setMargin(Vector2f margin) {
+        this.xMargin = margin.x;
+        this.yMargin = margin.y;
+    }
+
     public Vector2f getMargin() {
         return new Vector2f(xMargin, yMargin);
     }

--- a/src/main/java/com/simsilica/lemur/component/TbtQuadBackgroundComponent.java
+++ b/src/main/java/com/simsilica/lemur/component/TbtQuadBackgroundComponent.java
@@ -241,6 +241,11 @@ public class TbtQuadBackgroundComponent extends AbstractGuiComponent
         invalidate();
     }
 
+    public void setMargin(Vector2f margin) {
+        this.xMargin = margin.x;
+        this.yMargin = margin.y;
+    }
+
     public float getZOffset() {
         return zOffset;
     }


### PR DESCRIPTION

Currently the gradle version used does not allow compiling on anything above Java 9. Upgrading to gradle 5.6.4 solves this issue.

Adding a constructor to IconComponent to allow passing a texture will allow users to specify textures that are not loaded from a filesystem.