### PR TITLE
TextEntryComponent: consume non-char events generated by lwjgl3

### DIFF
--- a/src/main/java/com/simsilica/lemur/component/TextEntryComponent.java
+++ b/src/main/java/com/simsilica/lemur/component/TextEntryComponent.java
@@ -763,6 +763,8 @@ public class TextEntryComponent extends AbstractGuiComponent
                     model.insert(evt.getKeyChar());
                     evt.setConsumed();
                     //resetText(); ...should be automatic now
+                } else if (evt.getKeyChar() == '\0') {
+                    evt.setConsumed();
                 }
             }
         }


### PR DESCRIPTION
This will block the redundant key events while the text entry is focused.

Fix https://hub.jmonkeyengine.org/t/behavior-difference-in-textarea-between-lwjgl-2-and-3/45652

